### PR TITLE
Add support  for converting html to slack hyperlink

### DIFF
--- a/lib/slack_transformer/html.rb
+++ b/lib/slack_transformer/html.rb
@@ -1,5 +1,6 @@
 require 'slack_transformer/html/bold'
 require 'slack_transformer/html/code'
+require 'slack_transformer/html/hyperlinks'
 require 'slack_transformer/html/italics'
 require 'slack_transformer/html/lists'
 require 'slack_transformer/html/preformatted'
@@ -15,7 +16,8 @@ module SlackTransformer
       SlackTransformer::Html::Strikethrough,
       SlackTransformer::Html::Code,
       SlackTransformer::Html::Preformatted,
-      SlackTransformer::Html::Lists
+      SlackTransformer::Html::Lists,
+      SlackTransformer::Html::Hyperlinks
     ]
 
     def initialize(input)

--- a/lib/slack_transformer/html/hyperlinks.rb
+++ b/lib/slack_transformer/html/hyperlinks.rb
@@ -21,7 +21,6 @@ module SlackTransformer
           end
         end
 
-        p links_to_replace
         links_to_replace.each do |html, hyperlink|
           input.gsub!(html, hyperlink)
         end

--- a/lib/slack_transformer/html/hyperlinks.rb
+++ b/lib/slack_transformer/html/hyperlinks.rb
@@ -1,0 +1,23 @@
+module SlackTransformer
+  class Html
+    class Hyperlinks
+      attr_reader :input
+
+      def initialize(input)
+        @input = input
+      end
+
+      def to_slack
+        fragment = Nokogiri::HTML.fragment(input)
+
+        fragment.children.each do |child|
+          if child.name == 'a'
+            hyperlink_text = child.text || child.attr('href')
+            hyperlink = "<#{child.attr('href')}|#{hyperlink_text}>"
+            input = input.gsub(child.to_s, hyperlink)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_transformer/html/hyperlinks.rb
+++ b/lib/slack_transformer/html/hyperlinks.rb
@@ -1,3 +1,5 @@
+require 'nokogiri'
+
 module SlackTransformer
   class Html
     class Hyperlinks
@@ -10,13 +12,21 @@ module SlackTransformer
       def to_slack
         fragment = Nokogiri::HTML.fragment(input)
 
+        links_to_replace = {}
         fragment.children.each do |child|
           if child.name == 'a'
-            hyperlink_text = child.text || child.attr('href')
+            hyperlink_text = child.text.empty? ? child.attr('href') : child.text
             hyperlink = "<#{child.attr('href')}|#{hyperlink_text}>"
-            input = input.gsub(child.to_s, hyperlink)
+            links_to_replace[child.to_s] = hyperlink
           end
         end
+
+        p links_to_replace
+        links_to_replace.each do |html, hyperlink|
+          input.gsub!(html, hyperlink)
+        end
+
+      input
       end
     end
   end

--- a/spec/slack_transformer/html/hyperlinks_spec.rb
+++ b/spec/slack_transformer/html/hyperlinks_spec.rb
@@ -1,0 +1,21 @@
+require 'slack_transformer/html/hyperlinks'
+
+RSpec.describe SlackTransformer::Html::Hyperlinks do
+  let(:transformation) { described_class.new(input) }
+
+  describe '#to_slack' do
+    context 'when hyperlink text is present' do
+      let(:input) { '<a href="test.com">test link</a>' }
+      it 'replaces HTML a Tag with slack hyperlink' do
+          expect(transformation.to_slack).to eq('<test.com|test link>')
+      end
+    end
+
+    context 'when hyperlink text is not present' do
+      let(:input) { '<a href="test.com"></a>' }
+      it 'uses the href as the hyperlink text' do
+        expect(transformation.to_slack).to eq('<test.com|test.com>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use nokogiri to find links and replace them with the proper hyperlink format https://api.slack.com/reference/surfaces/formatting#links